### PR TITLE
add new constructor for CmsSignatureServiceImpl

### DIFF
--- a/api-sdk-crypto/src/main/java/com/alfa/api/sdk/crypto/impl/CmsSignatureServiceImpl.java
+++ b/api-sdk-crypto/src/main/java/com/alfa/api/sdk/crypto/impl/CmsSignatureServiceImpl.java
@@ -44,6 +44,17 @@ public class CmsSignatureServiceImpl extends AbstractSignatureService implements
         this.signedDataEncoding = signedDataEncoding;
     }
 
+    public CmsSignatureServiceImpl(KeyStoreParameters parameters, SignatureAlgorithm signatureAlgorithm, SignedDataEncoding signedDataEncoding) {
+        super(parameters, signatureAlgorithm);
+        this.signedDataEncoding = signedDataEncoding.name();
+    }
+
+    public enum SignedDataEncoding {
+        DER,
+        BER,
+        DL
+    }
+
     @Override
     public byte[] signDetached(byte[] data) {
         return sign(data, false);


### PR DESCRIPTION
Added new constructor for CmsSignatureServiceImpl with enum SignedDataEncoding (istead of String signedDataEncoding).
The previous version was retained for backward compatibility.